### PR TITLE
Corrects package import so it works on Python 2 & 3

### DIFF
--- a/array_devices/__init__.py
+++ b/array_devices/__init__.py
@@ -1,1 +1,1 @@
-from array3710 import Load, Program, ProgramStep
+from .array3710 import Load, Program, ProgramStep


### PR DESCRIPTION
The existing code does not import properly with Python 3:

```
$ python3
Python 3.5.1 (v3.5.1:37a07cee5969, Dec  5 2015, 21:12:44) 
[GCC 4.2.1 (Apple Inc. build 5666) (dot 3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import array_devices
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/rjs/dev/array_devices/array_devices/__init__.py", line 1, in <module>
    from array3710 import Load, Program, ProgramStep
 ImportError: No module named 'array3710'
```

This pull request modifies the import statement in `__init__.py` so it works correctly on both Python 2 and Python 3.
